### PR TITLE
Make the README display correctly in Github flavored markdown

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,25 +1,25 @@
-<A name="toc1-0" title="What?" />
-# What?
+# What? <A name="toc1-0" title="What?" />
+
 
 This is a library that if you load it into a webpage just ruins it subtly and drives the user nuts. It's awful and you shouldn't use it.
 
-<A name="toc1-5" title="Contributing" />
-# Contributing
+
+# Contributing <A name="toc1-5" title="Contributing" />
 
 If you want to help make this joke of a horrible thing even more funny and terrible, then go ahead. Edit stuff in. I'll merge any not completely off-base pull request.
 
 Nobody is using this in production one hopes, so we're not too worried about breaking it.
 
-<A name="toc1-12" title="License" />
-# License
+# License <A name="toc1-12" title="License" />
 
 This library is licensed under the MIT license.
 
-<A name="toc1-17" title="Toolbox" />
-# Toolbox
 
-1) Do nasty things (works in chrome) - on scroll.
+# Toolbox <A name="toc1-17" title="Toolbox" /> 
 
+1. Do nasty things (works in chrome) - on scroll.
+```
     window.onscroll = function(event){ughjs_run()};
+```
 
-2) Fill in here
+2. Fill in here


### PR DESCRIPTION
Moved the target anchors to after the titles so that the titles are recognized as titles. Did some fiddling with the code sample at the bottom to make it look okay.